### PR TITLE
Password Lockout and validation

### DIFF
--- a/IdentityDomain/IdentityDomain.csproj
+++ b/IdentityDomain/IdentityDomain.csproj
@@ -6,7 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="3.1.8" />

--- a/WebUI/Startup.cs
+++ b/WebUI/Startup.cs
@@ -70,6 +70,11 @@ namespace WebUI
                     options.User.RequireUniqueEmail = true;
 
                     options.Tokens.EmailConfirmationTokenProvider = "demoEmailConfirmation";
+
+                    options.Lockout.AllowedForNewUsers = true;
+                    options.Lockout.MaxFailedAccessAttempts = 3;
+                    options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromHours(1);
+
                 })
                 .AddEntityFrameworkStores<DemoDbContext>()
                 .AddDefaultTokenProviders() // for things like forgot password tokens

--- a/WebUI/Startup.cs
+++ b/WebUI/Startup.cs
@@ -21,6 +21,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using ScottBrady91.AspNetCore.Identity;
 
 namespace WebUI
 {
@@ -63,13 +64,18 @@ namespace WebUI
                     options.Password.RequireUppercase = true; // default, just stateing it explicitly
                     options.Password.RequireNonAlphanumeric = true; // default, just stateing it explicitly
                     options.Password.RequireDigit = true; // default, just stateing it explicitly
+
                     options.SignIn.RequireConfirmedEmail = true; // default, just stateing it explicitly
+
+                    options.User.RequireUniqueEmail = true;
+
                     options.Tokens.EmailConfirmationTokenProvider = "demoEmailConfirmation";
                 })
                 .AddEntityFrameworkStores<DemoDbContext>()
                 .AddDefaultTokenProviders() // for things like forgot password tokens
-                .AddTokenProvider<EmailConfirmationTokenProvider<DemoUser>>("demoEmailConfirmation");
-
+                .AddTokenProvider<EmailConfirmationTokenProvider<DemoUser>>("demoEmailConfirmation")
+                .AddPasswordValidator<DemoPasswordValidator<DemoUser>>();
+            //services.AddScoped<IPasswordHasher<DemoUser>, BCryptPasswordHasher<DemoUser>>();
             services.AddScoped<IUserClaimsPrincipalFactory<DemoUser>, DemoUserClaimsPrincipalFactory>();
 
             services.ConfigureApplicationCookie(options => options.LoginPath = "/Home/Login");
@@ -78,8 +84,8 @@ namespace WebUI
             services.Configure<DataProtectionTokenProviderOptions>(options =>
                 options.TokenLifespan = TimeSpan.FromMinutes(30)); 
             services.Configure<EmailConfirmationTokenProviderOptions>(options =>
-                options.TokenLifespan = TimeSpan.FromDays(2)); 
-
+                options.TokenLifespan = TimeSpan.FromDays(2));
+            services.Configure<PasswordHasherOptions>(options => options.IterationCount = 100_000);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/WebUI/Views/Home/Register.cshtml
+++ b/WebUI/Views/Home/Register.cshtml
@@ -34,6 +34,7 @@
             <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-primary" />
             </div>
+            <div asp-validation-summary="All"></div>
         </form>
     </div>
 </div>

--- a/WebUI/Views/Home/Register.cshtml
+++ b/WebUI/Views/Home/Register.cshtml
@@ -10,7 +10,6 @@
 <div class="row">
     <div class="col-md-4">
         <form asp-action="Register">
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <div class="form-group">
                 <label asp-for="UserName" class="control-label"></label>
                 <input asp-for="UserName" class="form-control" />
@@ -34,7 +33,7 @@
             <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-primary" />
             </div>
-            <div asp-validation-summary="All"></div>
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
         </form>
     </div>
 </div>

--- a/WebUI/WebUI.csproj
+++ b/WebUI/WebUI.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="3.1.8" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.4" />
+    <PackageReference Include="ScottBrady91.AspNetCore.Identity.BCryptPasswordHasher" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Additions

- added if using user manager code - filled in the missing pieces for using user manager rather than SignInManager
- removed reference to identity package - replaced reference to identity (2.2) with framework reference to AspNetCore.App as identity was moved into the core framework in 3.1 (or 3.0)
- add custom password validator - added custom password validator - registered custom validator - errors not yet correclty display when requirements not met
- lockout support added - set default lockout settings to enable at 3 failed attempts with 1 hour timespan
- updated homecontroller to check lock out - in 'commented out' code block for user manager it performs the checks to verify the locked out state and logs (eventually e-mail) the user that they're locked out - relocated error details for register - updated Register to add create errors to model state

## Remarks

- doesn't actually cover revocation just lock out and validation for passwords, the library adds a security stamp which can be used as a way to revoke of sorts, something I'll need to come back to at some point
